### PR TITLE
Improve prompt route error handling and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ Sharp Coder is a comprehensive AI-powered coding platform that provides develope
 
 Sharp Coder includes a Next.js API route that connects to Google Gemini for prompt enhancement. The service rewrites user prompts using an eight-step scaffold to clarify intent, surface context, enumerate constraints, and ensure coherent outputs. Source code lives in `lib/chatService.ts` with an accompanying route handler at `app/api/improve-prompt/route.ts`. Unit tests reside in `tests/` to validate normal usage, error conditions, and request timeouts.
 
+To use the service you must supply a valid `GEMINI_API_KEY` environment variable. The route responds with clear errors for common issues:
+
+- `400` for malformed JSON payloads
+- `400` when `prompt` is missing or not a string
+- `500` if `GEMINI_API_KEY` is not set
+- `500` with upstream Gemini status codes and messages when the external API fails
+
 ## 📋 Prerequisites
 
 Before running this project, make sure you have the following installed:

--- a/app/api/improve-prompt/route.ts
+++ b/app/api/improve-prompt/route.ts
@@ -1,17 +1,33 @@
 import { NextRequest, NextResponse } from "next/server";
 import { ChatService } from "../../../lib/chatService";
 
-const config = {
-  apiKey: process.env.GEMINI_API_KEY || "AIzaSyDfKNJx0wL0IPIw-ONOO4AahEqUBLcmAcw",
-  model: process.env.GEMINI_MODEL || "gemini-pro"
-};
-
 export async function POST(req: NextRequest): Promise<NextResponse> {
   try {
-    const { prompt } = await req.json();
+    let body: any;
+    try {
+      body = await req.json();
+    } catch (err) {
+      console.error("Invalid JSON body", err);
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const { prompt } = body || {};
     if (typeof prompt !== "string") {
+      console.error("Prompt must be a string", { prompt });
       return NextResponse.json({ error: "Prompt must be a string" }, { status: 400 });
     }
+
+    const apiKey = process.env.GEMINI_API_KEY;
+    if (!apiKey) {
+      console.error("GEMINI_API_KEY is not set");
+      return NextResponse.json({ error: "GEMINI_API_KEY is not set" }, { status: 500 });
+    }
+
+    const config = {
+      apiKey,
+      model: process.env.GEMINI_MODEL || "gemini-pro",
+    };
+
     const service = new ChatService(config);
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 15000);
@@ -22,7 +38,9 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       clearTimeout(timeout);
     }
   } catch (err: any) {
+    console.error("Error handling /api/improve-prompt", err);
     const message = err?.name === "AbortError" ? "Request timed out" : err?.message || "Unexpected error";
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,9 +6,12 @@ This directory contains unit tests for the Next.js Gemini integration.
   - returning a placeholder for empty prompts
   - sending system and user messages to the Gemini API
   - handling network failures gracefully
+  - surfacing structured and plain-text API error responses
   - propagating abort errors for timed-out requests
 - `improvePromptRoute.test.ts` exercises the API route with:
   - successful prompt enhancement
   - validation of non-string prompts
   - simulated service failures
   - timeout abort handling
+  - invalid JSON bodies
+  - missing `GEMINI_API_KEY`

--- a/tests/chatService.test.ts
+++ b/tests/chatService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   ChatService,
   PLACEHOLDER_RESPONSE,
@@ -11,6 +11,15 @@ describe("ChatService", () => {
     apiKey: "key",
     model: "gemini-pro"
   };
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
 
   it("returns placeholder when prompt is empty", async () => {
     const svc = new ChatService(config, (() => Promise.reject(new Error("should not call"))) as any);
@@ -45,7 +54,35 @@ describe("ChatService", () => {
     const fetchMock = () => Promise.reject(new Error("network"));
     const svc = new ChatService(config, fetchMock as any);
     await expect(svc.improvePrompt("test")).rejects.toThrow("network");
+    expect(errorSpy).toHaveBeenCalled();
+  });
 
+  it("includes structured error details", async () => {
+    const fetchMock = () =>
+      Promise.resolve({
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve(JSON.stringify({ error: { message: "bad" } }))
+      });
+    const svc = new ChatService(config, fetchMock as any);
+    await expect(svc.improvePrompt("test")).rejects.toThrow(
+      "Request failed with status 400: bad"
+    );
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("falls back to text error responses", async () => {
+    const fetchMock = () =>
+      Promise.resolve({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve("server exploded")
+      });
+    const svc = new ChatService(config, fetchMock as any);
+    await expect(svc.improvePrompt("test")).rejects.toThrow(
+      "Request failed with status 500: server exploded"
+    );
+    expect(errorSpy).toHaveBeenCalled();
   });
 
   it("propagates abort errors", async () => {
@@ -62,6 +99,7 @@ describe("ChatService", () => {
     const promise = svc.improvePrompt("test", controller.signal);
     controller.abort();
     await expect(promise).rejects.toHaveProperty("name", "AbortError");
+    expect(errorSpy).toHaveBeenCalled();
   });
 });
 

--- a/tests/improvePromptRoute.test.ts
+++ b/tests/improvePromptRoute.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 
 const improvePromptMock = vi.fn();
@@ -8,8 +8,16 @@ vi.mock("../lib/chatService", () => ({
 
 import { POST } from "../app/api/improve-prompt/route";
 
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
 beforeEach(() => {
   improvePromptMock.mockReset();
+  process.env.GEMINI_API_KEY = "test-key";
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
 });
 
 describe("improve-prompt API route", () => {
@@ -24,6 +32,7 @@ describe("improve-prompt API route", () => {
     const res = await POST(req);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ result: "better" });
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 
   it("validates prompt type", async () => {
@@ -36,6 +45,7 @@ describe("improve-prompt API route", () => {
     const res = await POST(req);
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: "Prompt must be a string" });
+    expect(errorSpy).toHaveBeenCalled();
   });
 
   it("handles service errors", async () => {
@@ -49,6 +59,7 @@ describe("improve-prompt API route", () => {
     const res = await POST(req);
     expect(res.status).toBe(500);
     expect(await res.json()).toEqual({ error: "boom" });
+    expect(errorSpy).toHaveBeenCalled();
   });
 
   it("handles timeout aborts", async () => {
@@ -64,5 +75,33 @@ describe("improve-prompt API route", () => {
     const res = await POST(req);
     expect(res.status).toBe(500);
     expect(await res.json()).toEqual({ error: "Request timed out" });
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const req = new NextRequest(
+      new Request("http://test", {
+        method: "POST",
+        body: "{ invalid",
+      }),
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON body" });
+     expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("returns error when GEMINI_API_KEY is missing", async () => {
+    delete process.env.GEMINI_API_KEY;
+    const req = new NextRequest(
+      new Request("http://test", {
+        method: "POST",
+        body: JSON.stringify({ prompt: "test" }),
+      }),
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "GEMINI_API_KEY is not set" });
+    expect(errorSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- validate JSON body and require `GEMINI_API_KEY` in prompt improvement route
- surface detailed upstream errors in `ChatService` and log all failures to the console
- expand tests and documentation for new error cases

## Testing
- `pnpm test`
- `pnpm lint` *(warning: no-img-element in components/import-figma.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c6c7ef488328931ea282d20cb962