### PR TITLE
Add authentication and profile management

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Sharp Coder is a comprehensive AI-powered coding platform that provides develope
 - **Figma Integration** - Import designs directly from Figma with a dedicated dashboard button
 - **Git Integration** - Connect and sync with GitHub repositories
 - **Profile & Settings** - Comprehensive user management
+- **Authentication** - Email-based signup and login with profile access
 
 ### 🎨 UI/UX Features
 - **Dark/Light Theme** - Toggle between themes with persistent storage
@@ -42,6 +43,12 @@ Sharp Coder is a comprehensive AI-powered coding platform that provides develope
 - **File Upload** - Drag & drop screenshot support
 - **Real-time Preview** - Live code preview and generation
  - **Prompt Improvement Service** - Next.js API leveraging Google Gemini for scaffolded prompt refinement
+
+## ✅ Implemented Use Cases
+
+- Users can create accounts via the signup form.
+- Returning users may log in to retrieve their session.
+- Authenticated users can view their profile and adjust personal settings.
 
 ## 🏗 Tech Stack
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { GeistSans } from 'geist/font/sans'
 import { GeistMono } from 'geist/font/mono'
 import './globals.css'
 import { Toaster } from '@/components/ui/sonner'
+import { AuthProvider } from '@/contexts/auth-context'
 
 export const metadata: Metadata = {
   title: 'v0 App',
@@ -27,8 +28,10 @@ html {
         `}</style>
       </head>
       <body>
-        {children}
-        <Toaster />
+        <AuthProvider>
+          {children}
+          <Toaster />
+        </AuthProvider>
       </body>
     </html>
   )

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,5 @@
+import { LoginForm } from '@/components/login-form'
+
+export default function LoginPage() {
+  return <LoginForm />
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/contexts/auth-context'
+import { Profile } from '@/components/profile'
+
+export default function ProfilePage() {
+  const { user } = useAuth()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!user) router.replace('/login')
+  }, [user, router])
+
+  if (!user) return null
+
+  return <Profile />
+}

--- a/app/profile/settings/page.tsx
+++ b/app/profile/settings/page.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/contexts/auth-context'
+import { ProfileSettings } from '@/components/profile-settings'
+
+export default function ProfileSettingsPage() {
+  const { user } = useAuth()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!user) router.replace('/login')
+  }, [user, router])
+
+  if (!user) return null
+
+  return <ProfileSettings />
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,0 +1,5 @@
+import { SignupForm } from '@/components/signup-form'
+
+export default function SignupPage() {
+  return <SignupForm />
+}

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -1,0 +1,75 @@
+"use client"
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/contexts/auth-context'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card'
+import Link from 'next/link'
+
+export function LoginForm() {
+  const { login } = useAuth()
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+    try {
+      await login(email, password)
+      router.push('/profile')
+    } catch (err: any) {
+      setError(err.message || 'Login failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Card className="max-w-md mx-auto mt-20">
+      <form onSubmit={handleSubmit} noValidate>
+        <CardHeader>
+          <CardTitle>Login</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <label htmlFor="email" className="text-sm font-medium">Email</label>
+            <Input
+              id="email"
+              type="email"
+              autoComplete="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <label htmlFor="password" className="text-sm font-medium">Password</label>
+            <Input
+              id="password"
+              type="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+          {error && <p className="text-red-500 text-sm" role="alert">{error}</p>}
+        </CardContent>
+        <CardFooter className="flex flex-col space-y-2">
+          <Button type="submit" disabled={loading} className="w-full">
+            {loading ? 'Logging in...' : 'Login'}
+          </Button>
+          <p className="text-sm text-center">
+            No account? <Link href="/signup" className="underline">Sign up</Link>
+          </p>
+        </CardFooter>
+      </form>
+    </Card>
+  )
+}

--- a/components/profile.tsx
+++ b/components/profile.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { useAuth } from '@/contexts/auth-context'
+
+export function Profile() {
+  const { user, logout } = useAuth()
+
+  if (!user) {
+    return <p className="mt-10 text-center">No user logged in.</p>
+  }
+
+  return (
+    <Card className="max-w-md mx-auto mt-10">
+      <CardHeader>
+        <CardTitle>Profile</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p>Email: {user.email}</p>
+        <div className="flex space-x-2">
+          <Link href="/profile/settings">
+            <Button variant="secondary">Settings</Button>
+          </Link>
+          <Button onClick={logout} variant="destructive">Logout</Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/signup-form.tsx
+++ b/components/signup-form.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/contexts/auth-context'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card'
+import Link from 'next/link'
+
+export function SignupForm() {
+  const { signup } = useAuth()
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+    try {
+      await signup(email, password)
+      router.push('/profile')
+    } catch (err: any) {
+      setError(err.message || 'Signup failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Card className="max-w-md mx-auto mt-20">
+      <form onSubmit={handleSubmit} noValidate>
+        <CardHeader>
+          <CardTitle>Sign Up</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <label htmlFor="email" className="text-sm font-medium">Email</label>
+            <Input
+              id="email"
+              type="email"
+              autoComplete="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <label htmlFor="password" className="text-sm font-medium">Password</label>
+            <Input
+              id="password"
+              type="password"
+              autoComplete="new-password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+          {error && <p className="text-red-500 text-sm" role="alert">{error}</p>}
+        </CardContent>
+        <CardFooter className="flex flex-col space-y-2">
+          <Button type="submit" disabled={loading} className="w-full">
+            {loading ? 'Signing up...' : 'Sign Up'}
+          </Button>
+          <p className="text-sm text-center">
+            Already have an account?{' '}
+            <Link href="/login" className="underline">
+              Login
+            </Link>
+          </p>
+        </CardFooter>
+      </form>
+    </Card>
+  )
+}

--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import { createContext, useContext, useState, ReactNode } from 'react'
+import { login as loginSvc, signup as signupSvc, logout as logoutSvc, getCurrentUser, User } from '@/lib/auth'
+
+interface AuthContextValue {
+  user: User | null
+  login: (email: string, password: string) => Promise<void>
+  signup: (email: string, password: string) => Promise<void>
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(getCurrentUser())
+
+  const login = async (email: string, password: string) => {
+    const u = await loginSvc(email, password)
+    setUser(u)
+  }
+
+  const signup = async (email: string, password: string) => {
+    const u = await signupSvc(email, password)
+    setUser(u)
+  }
+
+  const logout = () => {
+    logoutSvc()
+    setUser(null)
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, login, signup, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider')
+  return ctx
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,94 @@
+export interface User {
+  id: string
+  email: string
+  password: string
+  name?: string
+}
+
+const USERS_KEY = 'scv_users'
+const CURRENT_USER_KEY = 'scv_current_user'
+
+function loadUsers(): User[] {
+  if (typeof localStorage === 'undefined') return []
+  try {
+    const raw = localStorage.getItem(USERS_KEY)
+    return raw ? (JSON.parse(raw) as User[]) : []
+  } catch {
+    return []
+  }
+}
+
+function saveUsers(users: User[]): void {
+  if (typeof localStorage === 'undefined') return
+  localStorage.setItem(USERS_KEY, JSON.stringify(users))
+}
+
+function setCurrentUser(user: User | null): void {
+  if (typeof localStorage === 'undefined') return
+  if (user) localStorage.setItem(CURRENT_USER_KEY, JSON.stringify(user))
+  else localStorage.removeItem(CURRENT_USER_KEY)
+}
+
+export function getCurrentUser(): User | null {
+  if (typeof localStorage === 'undefined') return null
+  const raw = localStorage.getItem(CURRENT_USER_KEY)
+  return raw ? (JSON.parse(raw) as User) : null
+}
+
+function simulateNetwork<T>(result: () => T, signal?: AbortSignal): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    if (signal?.aborted) {
+      return reject(new DOMException('Aborted', 'AbortError'))
+    }
+    const timer = setTimeout(() => {
+      try {
+        resolve(result())
+      } catch (err) {
+        reject(err)
+      }
+    }, 10)
+
+    signal?.addEventListener('abort', () => {
+      clearTimeout(timer)
+      reject(new DOMException('Aborted', 'AbortError'))
+    })
+  })
+}
+
+export async function signup(
+  email: string,
+  password: string,
+  signal?: AbortSignal,
+): Promise<User> {
+  return simulateNetwork(() => {
+    const users = loadUsers()
+    if (users.some((u) => u.email === email)) {
+      throw new Error('Email already registered')
+    }
+    const user: User = { id: crypto.randomUUID(), email, password }
+    users.push(user)
+    saveUsers(users)
+    setCurrentUser(user)
+    return user
+  }, signal)
+}
+
+export async function login(
+  email: string,
+  password: string,
+  signal?: AbortSignal,
+): Promise<User> {
+  return simulateNetwork(() => {
+    const users = loadUsers()
+    const user = users.find((u) => u.email === email)
+    if (!user || user.password !== password) {
+      throw new Error('Invalid credentials')
+    }
+    setCurrentUser(user)
+    return user
+  }, signal)
+}
+
+export function logout(): void {
+  setCurrentUser(null)
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -23,3 +23,11 @@ This directory contains unit tests for the Next.js Gemini integration.
 - `dashboard.test.tsx` confirms the dashboard:
   - displays the "Create an Application" preset
   - routes to the Figma import screen when the import button is clicked
+- `authService.test.ts` checks authentication service helpers by:
+  - signing up and logging in users
+  - preventing duplicate registrations
+  - rejecting invalid credentials
+  - aborting in-flight requests
+- `authFlow.test.tsx` exercises the login and signup forms ensuring:
+  - successful form submission triggers navigation
+  - authentication errors surface to the user

--- a/tests/authFlow.test.tsx
+++ b/tests/authFlow.test.tsx
@@ -1,0 +1,66 @@
+/** @vitest-environment jsdom */
+
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { LoginForm } from '../components/login-form'
+import { SignupForm } from '../components/signup-form'
+
+const loginMock = vi.fn()
+const signupMock = vi.fn()
+const pushMock = vi.fn()
+
+vi.mock('../contexts/auth-context', () => ({
+  useAuth: () => ({ login: loginMock, signup: signupMock })
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock })
+}))
+
+describe('Authentication forms', () => {
+  beforeEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('logs in user and redirects to profile', async () => {
+    loginMock.mockResolvedValueOnce(undefined)
+    render(<LoginForm />)
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'a@test.com' } })
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'pw' } })
+    fireEvent.click(screen.getByRole('button', { name: /login/i }))
+    await waitFor(() => expect(loginMock).toHaveBeenCalledWith('a@test.com', 'pw'))
+    expect(pushMock).toHaveBeenCalledWith('/profile')
+  })
+
+  it('shows login error', async () => {
+    loginMock.mockRejectedValueOnce(new Error('Invalid credentials'))
+    render(<LoginForm />)
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'a@test.com' } })
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'bad' } })
+    fireEvent.click(screen.getByRole('button', { name: /login/i }))
+    await waitFor(() => screen.getByRole('alert'))
+    expect(screen.getByRole('alert')).toHaveTextContent('Invalid credentials')
+  })
+
+  it('signs up user and redirects', async () => {
+    signupMock.mockResolvedValueOnce(undefined)
+    render(<SignupForm />)
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'b@test.com' } })
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'pw' } })
+    fireEvent.click(screen.getByRole('button', { name: /sign up/i }))
+    await waitFor(() => expect(signupMock).toHaveBeenCalledWith('b@test.com', 'pw'))
+    expect(pushMock).toHaveBeenCalledWith('/profile')
+  })
+
+  it('shows signup error', async () => {
+    signupMock.mockRejectedValueOnce(new Error('Email already registered'))
+    render(<SignupForm />)
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'b@test.com' } })
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'pw' } })
+    fireEvent.click(screen.getByRole('button', { name: /sign up/i }))
+    await waitFor(() => screen.getByRole('alert'))
+    expect(screen.getByRole('alert')).toHaveTextContent('Email already registered')
+  })
+})

--- a/tests/authService.test.ts
+++ b/tests/authService.test.ts
@@ -1,0 +1,36 @@
+/** @vitest-environment jsdom */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { signup, login, logout, getCurrentUser } from '../lib/auth'
+
+describe('auth service', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('signs up and logs in user', async () => {
+    const user = await signup('a@test.com', 'pw')
+    expect(user.email).toBe('a@test.com')
+    logout()
+    const logged = await login('a@test.com', 'pw')
+    expect(logged.email).toBe('a@test.com')
+    expect(getCurrentUser()?.email).toBe('a@test.com')
+  })
+
+  it('rejects duplicate signup', async () => {
+    await signup('a@test.com', 'pw')
+    await expect(signup('a@test.com', 'pw')).rejects.toThrow(/already/i)
+  })
+
+  it('rejects invalid login', async () => {
+    await signup('a@test.com', 'pw')
+    await expect(login('a@test.com', 'wrong')).rejects.toThrow(/invalid/i)
+  })
+
+  it('aborts requests', async () => {
+    const ac = new AbortController()
+    const promise = signup('b@test.com', 'pw', ac.signal)
+    ac.abort()
+    await expect(promise).rejects.toThrow(/aborted/i)
+  })
+})


### PR DESCRIPTION
## Summary
- implement localStorage-based signup/login/logout utilities and auth context
- add profile, profile settings, login and signup pages with accessible UI
- cover authentication workflows with unit and integration tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6f39eeee88328833f62359dec3f72