### PR TITLE
fix: refine authentication flow and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Sharp Coder is a comprehensive AI-powered coding platform that provides develope
 - Returning users with an active session only supply an authenticator code to log in.
 - Authenticated users can view their profile and adjust personal settings with pre-filled data.
 - User records persist in Firebase with session-based redirects.
+- Authentication services enforce error handling for duplicate signups, invalid logins, and aborted requests.
 
 ## 🏗 Tech Stack
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -25,15 +25,26 @@ async function clientRequest(path: string, data: any, signal?: AbortSignal): Pro
   return payload
 }
 
-export async function signup(name: string, email: string, password: string, signal?: AbortSignal): Promise<void> {
+export async function signup(
+  name: string,
+  email: string,
+  password: string,
+  signal?: AbortSignal
+): Promise<User> {
   const res = await clientRequest('/api/auth/signup', { name, email, password }, signal)
   setPending(res.email, res.name)
   if (res.otpauth) localStorage.setItem('scv_otpauth', res.otpauth)
+  return { id: res.id, email: res.email, name: res.name } as User
 }
 
-export async function login(email: string, password: string, signal?: AbortSignal): Promise<void> {
+export async function login(
+  email: string,
+  password: string,
+  signal?: AbortSignal
+): Promise<User> {
   const res = await clientRequest('/api/auth/login', { email, password }, signal)
   setPending(res.email, res.name)
+  return { id: res.id, email: res.email, name: res.name } as User
 }
 
 export async function verify(token: string, signal?: AbortSignal): Promise<User> {

--- a/tests/README.md
+++ b/tests/README.md
@@ -23,6 +23,11 @@ This directory contains unit tests for the Next.js Gemini integration.
 - `dashboard.test.tsx` confirms the dashboard:
   - displays the "Create an Application" preset
   - routes to the Figma import screen when the import button is clicked
+- `authService.test.ts` covers the authentication service layer, verifying:
+  - successful signup, login, and OTP verification create a session
+  - duplicate signups are rejected
+  - invalid login attempts are rejected
+  - requests respect `AbortController` cancellations
 - `authFlow.test.tsx` exercises the login and signup forms ensuring:
   - successful login followed by OTP verification navigates to the dashboard
   - signup collects a full name and redirects to authenticator setup

--- a/tests/authService.test.ts
+++ b/tests/authService.test.ts
@@ -1,41 +1,78 @@
 /** @vitest-environment jsdom */
 
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import path from 'path'
 import { tmpdir } from 'os'
 import fs from 'fs/promises'
+import { authenticator } from 'otplib'
 
 process.env.DB_PATH = path.join(tmpdir(), 'auth-test-users.json')
-import { signup, login, logout, getCurrentUser } from '../lib/auth'
+
+import { signup, login, verify, getCurrentUser } from '../lib/auth'
+import * as server from '../lib/auth.server'
+
+function mockFetch() {
+  vi.stubGlobal('fetch', (url: RequestInfo, options?: RequestInit) => {
+    const { signal } = options ?? {}
+    return new Promise<Response>((resolve, reject) => {
+      if (signal?.aborted) return reject(new DOMException('Aborted', 'AbortError'))
+      const onAbort = () => reject(new DOMException('Aborted', 'AbortError'))
+      signal?.addEventListener('abort', onAbort)
+      setTimeout(async () => {
+        try {
+          const body = JSON.parse((options?.body as string) || '{}')
+          let data: any
+          if (url === '/api/auth/signup') {
+            data = await server.signup(body.name, body.email, body.password)
+          } else if (url === '/api/auth/login') {
+            data = await server.login(body.email, body.password)
+          } else if (url === '/api/auth/verify') {
+            data = await server.verify(body.email, body.token)
+          } else {
+            throw new Error('Unknown endpoint')
+          }
+          resolve(new Response(JSON.stringify(data), { status: 200 }))
+        } catch (err: any) {
+          resolve(new Response(JSON.stringify({ error: err.message }), { status: 400 }))
+        } finally {
+          signal?.removeEventListener('abort', onAbort)
+        }
+      }, 0)
+    })
+  })
+}
 
 describe('auth service', () => {
   beforeEach(async () => {
     localStorage.clear()
     await fs.rm(process.env.DB_PATH!, { force: true })
+    vi.unstubAllGlobals()
+    mockFetch()
   })
 
-  it('signs up and logs in user', async () => {
-    const user = await signup('a@test.com', 'pw')
-    expect(user.email).toBe('a@test.com')
-    logout()
-    const logged = await login('a@test.com', 'pw')
-    expect(logged.email).toBe('a@test.com')
+  it('signs up, logs in, verifies, and stores session', async () => {
+    await signup('Alice', 'a@test.com', 'pw')
+    await login('a@test.com', 'pw')
+    const otpauth = localStorage.getItem('scv_otpauth')!
+    const secret = new URL(otpauth).searchParams.get('secret')!
+    const code = authenticator.generate(secret)
+    await verify(code)
     expect(getCurrentUser()?.email).toBe('a@test.com')
   })
 
   it('rejects duplicate signup', async () => {
-    await signup('a@test.com', 'pw')
-    await expect(signup('a@test.com', 'pw')).rejects.toThrow(/already/i)
+    await signup('Bob', 'b@test.com', 'pw')
+    await expect(signup('Bob', 'b@test.com', 'pw')).rejects.toThrow(/already/i)
   })
 
   it('rejects invalid login', async () => {
-    await signup('a@test.com', 'pw')
-    await expect(login('a@test.com', 'wrong')).rejects.toThrow(/invalid/i)
+    await signup('Eve', 'e@test.com', 'pw')
+    await expect(login('e@test.com', 'bad')).rejects.toThrow(/invalid/i)
   })
 
   it('aborts requests', async () => {
     const ac = new AbortController()
-    const promise = signup('b@test.com', 'pw', ac.signal)
+    const promise = signup('Tom', 't@test.com', 'pw', ac.signal)
     ac.abort()
     await expect(promise).rejects.toThrow(/aborted/i)
   })


### PR DESCRIPTION
## Summary
- return user details from signup and login helpers
- expand auth service tests with mocked API endpoints and OTP verification
- document authentication test coverage and error handling

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8242dea7c8328b4e2c3255328fb33