### PR TITLE
refactor: load firebase creds from env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ yarn-error.log*
 
 # env files
 .env*
+firebase-service-account.json
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Before running this project, make sure you have the following installed:
 - **Node.js** (version 18.0 or higher)
 - **npm** (version 9.0 or higher) or **yarn** or **pnpm**
 - **Git** (for version control)
-- **Firebase service account** set in the `FIREBASE_SERVICE_ACCOUNT` environment variable
+- **Firebase service account** provided via the `FIREBASE_SERVICE_ACCOUNT` environment variable or a file referenced by `FIREBASE_SERVICE_ACCOUNT_PATH`; the project ID is derived from these credentials or from `GCLOUD_PROJECT`/`GOOGLE_CLOUD_PROJECT`
 
 Check your versions:
 \`\`\`bash

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,13 +1,40 @@
-import { cert, getApps, initializeApp } from 'firebase-admin/app'
+import { cert, getApps, initializeApp, type AppOptions, type ServiceAccount } from 'firebase-admin/app'
 import { getFirestore } from 'firebase-admin/firestore'
+import { readFileSync } from 'node:fs'
+import { isAbsolute, join } from 'node:path'
 
-const credJson = process.env.FIREBASE_SERVICE_ACCOUNT
-  ? JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT)
-  : undefined
+let credJson: ServiceAccount | undefined
+let projectId: string | undefined
+
+if (process.env.FIREBASE_SERVICE_ACCOUNT) {
+  try {
+    credJson = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT) as ServiceAccount
+    projectId = credJson.projectId ?? (credJson as Record<string, unknown>)['project_id'] as string | undefined
+  } catch {
+    // ignore invalid JSON in env variable
+  }
+} else if (process.env.FIREBASE_SERVICE_ACCOUNT_PATH) {
+  try {
+    const p = process.env.FIREBASE_SERVICE_ACCOUNT_PATH
+    const filePath = isAbsolute(p) ? p : join(process.cwd(), p)
+    const contents = readFileSync(filePath, 'utf8')
+    credJson = JSON.parse(contents) as ServiceAccount
+    projectId = credJson.projectId ?? (credJson as Record<string, unknown>)['project_id'] as string | undefined
+  } catch {
+    // ignore missing or invalid credential file
+  }
+}
+
+if (!projectId) {
+  projectId = process.env.GCLOUD_PROJECT ?? process.env.GOOGLE_CLOUD_PROJECT ?? undefined
+}
 
 if (!getApps().length) {
-  if (credJson) {
-    initializeApp({ credential: cert(credJson) })
+  const options: AppOptions = {}
+  if (credJson) options.credential = cert(credJson)
+  if (projectId) options.projectId = projectId
+  if (Object.keys(options).length) {
+    initializeApp(options)
   } else {
     initializeApp()
   }

--- a/tests/README.md
+++ b/tests/README.md
@@ -35,3 +35,6 @@ This directory contains unit tests for the Next.js Gemini integration.
 - `rootRedirect.test.tsx` ensures the landing page redirects based on session state:
   - missing or expired sessions route to login
   - valid sessions show the dashboard
+- `db.test.ts` verifies the database layer persists and retrieves users when a file-based store is configured.
+- `firebase.test.ts` checks Firebase initialization, covering env credentials, file-path credentials, invalid JSON, default initialization when credentials are absent, and project ID detection via service accounts or `GCLOUD_PROJECT`.
+

--- a/tests/firebase.test.ts
+++ b/tests/firebase.test.ts
@@ -1,0 +1,75 @@
+/** @vitest-environment node */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mkdtemp, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+const initializeApp = vi.fn()
+const getApps = vi.fn(() => [])
+const cert = vi.fn((cred: unknown) => cred)
+
+vi.mock('firebase-admin/app', () => ({ initializeApp, getApps, cert }))
+vi.mock('firebase-admin/firestore', () => ({ getFirestore: vi.fn(() => ({})) }))
+
+describe('firebase initialization', () => {
+  let cwdSpy: ReturnType<typeof vi.spyOn> | undefined
+
+  beforeEach(() => {
+    vi.resetModules()
+    initializeApp.mockClear()
+    getApps.mockReturnValue([])
+    delete process.env.FIREBASE_SERVICE_ACCOUNT
+    delete process.env.FIREBASE_SERVICE_ACCOUNT_PATH
+    delete process.env.GCLOUD_PROJECT
+    delete process.env.GOOGLE_CLOUD_PROJECT
+    cwdSpy?.mockRestore()
+    cwdSpy = undefined
+  })
+
+  it('uses credentials from FIREBASE_SERVICE_ACCOUNT env variable', async () => {
+    process.env.FIREBASE_SERVICE_ACCOUNT = JSON.stringify({ project_id: 'env' })
+    await import('../lib/firebase')
+    expect(initializeApp).toHaveBeenCalledWith({
+      credential: { project_id: 'env' },
+      projectId: 'env',
+    })
+  })
+
+  it('uses credentials from FIREBASE_SERVICE_ACCOUNT_PATH when provided', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'firebase-test-'))
+    const credPath = join(dir, 'firebase.json')
+    await writeFile(credPath, JSON.stringify({ project_id: 'file' }), 'utf8')
+    process.env.FIREBASE_SERVICE_ACCOUNT_PATH = credPath
+    await import('../lib/firebase')
+    expect(initializeApp).toHaveBeenCalledWith({
+      credential: { project_id: 'file' },
+      projectId: 'file',
+    })
+  })
+
+  it('initializes without credentials if none are available', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'firebase-test-'))
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(dir)
+    await import('../lib/firebase')
+    expect(initializeApp).toHaveBeenCalledWith()
+  })
+
+  it('uses GCLOUD_PROJECT when no credentials are provided', async () => {
+    process.env.GCLOUD_PROJECT = 'gc-env'
+    await import('../lib/firebase')
+    expect(initializeApp).toHaveBeenCalledWith({ projectId: 'gc-env' })
+  })
+
+  it('uses GOOGLE_CLOUD_PROJECT when GCLOUD_PROJECT is absent', async () => {
+    process.env.GOOGLE_CLOUD_PROJECT = 'gcp-env'
+    await import('../lib/firebase')
+    expect(initializeApp).toHaveBeenCalledWith({ projectId: 'gcp-env' })
+  })
+
+  it('ignores invalid JSON from FIREBASE_SERVICE_ACCOUNT', async () => {
+    process.env.FIREBASE_SERVICE_ACCOUNT = '{ invalid'
+    await import('../lib/firebase')
+    expect(initializeApp).toHaveBeenCalledWith()
+  })
+})


### PR DESCRIPTION
## Summary
- derive Firebase project ID from credentials or GCLOUD_PROJECT/GOOGLE_CLOUD_PROJECT env vars
- document project ID detection in prerequisites
- expand Firebase tests for env, path, and project ID fallbacks

## Testing
- `npm install`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8991f811c832893b355520702305b